### PR TITLE
Show likes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import './index.css';
 import getCharacters from './modules/characters.js';
 import createCard from './modules/createCard.js';
 import popupComments from './modules/commentsPopup.js';
-import postLike from './modules/involvementAPI.js';
+import { postLike, getLikes } from './modules/involvementAPI.js';
 // import getRandomArray from './modules/randomNumber.js';
 
 const containerPopup = document.querySelector('.popup');
@@ -27,3 +27,5 @@ charactersData.forEach((character) => {
   // console.log(card);
   container.appendChild(card);
 });
+
+getLikes();

--- a/src/index.js
+++ b/src/index.js
@@ -17,15 +17,15 @@ container.addEventListener('click', async (e) => {
     popupComments(characterDetail, containerPopup);
   } else if (e.target.classList.contains('like-img')) {
     const { id } = e.target.parentElement.parentElement.parentElement;
-    // console.log(id);
     await postLike(id);
+    const likesData = await getLikes();
+    const idIsEqualsTo = (likeObj, idx) => likeObj.item_id === idx;
+    const result = likesData.find((obj) => idIsEqualsTo(obj, id)) ?? 0;
+    e.target.parentElement.parentElement.children[2].textContent = `${result.likes ?? 0} Likes`;
   }
 });
 
 charactersData.forEach((character) => {
   const card = createCard(character);
-  // console.log(card);
   container.appendChild(card);
 });
-
-getLikes();

--- a/src/modules/createCard.js
+++ b/src/modules/createCard.js
@@ -1,4 +1,8 @@
 import likeImg from '../img/icons8-heart-32.png';
+import { getLikes } from './involvementAPI.js';
+
+const likesData = await getLikes();
+console.log(likesData[0]);
 
 const createCard = (character) => {
   const card = document.createElement('div');

--- a/src/modules/createCard.js
+++ b/src/modules/createCard.js
@@ -2,7 +2,6 @@ import likeImg from '../img/icons8-heart-32.png';
 import { getLikes } from './involvementAPI.js';
 
 const likesData = await getLikes();
-console.log(likesData[0]);
 
 const createCard = (character) => {
   const card = document.createElement('div');
@@ -31,8 +30,12 @@ const createCard = (character) => {
   likeButton.appendChild(likeButtonImg);
   container.appendChild(likeButton);
 
+  const idIsEqualsTo = (likeObj, idx) => likeObj.item_id === idx;
+  const result = likesData.find((obj) => idIsEqualsTo(obj, card.id)) ?? 0;
+  // console.log(result.likes ?? 0);
+
   const likesNumber = document.createElement('p');
-  likesNumber.textContent = '5 Likes';
+  likesNumber.textContent = `${result.likes ?? 0} Likes`;
   container.appendChild(likesNumber);
 
   const commentsButton = document.createElement('button');

--- a/src/modules/involvementAPI.js
+++ b/src/modules/involvementAPI.js
@@ -5,7 +5,6 @@ export const postLike = async (id) => {
   const bodyContent = JSON.stringify({
     item_id: id,
   });
-
   const response = await fetch(
     'https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/xqHl95viv3D6FREdQd3p/likes/',
     {
@@ -14,7 +13,6 @@ export const postLike = async (id) => {
       headers: headersList,
     },
   );
-
   const data = await response.text();
   // console.log(data);
   return data;
@@ -24,7 +22,7 @@ export const getLikes = async () => {
   const response = await fetch(
     'https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/xqHl95viv3D6FREdQd3p/likes',
   );
-  const likesData = await response.text();
-  console.log(likesData);
+  const likesData = await response.json();
+  // console.log(likesData);
   return likesData;
 };

--- a/src/modules/involvementAPI.js
+++ b/src/modules/involvementAPI.js
@@ -23,6 +23,5 @@ export const getLikes = async () => {
     'https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/xqHl95viv3D6FREdQd3p/likes',
   );
   const likesData = await response.json();
-  // console.log(likesData);
   return likesData;
 };

--- a/src/modules/involvementAPI.js
+++ b/src/modules/involvementAPI.js
@@ -1,4 +1,4 @@
-const postLike = async (id) => {
+export const postLike = async (id) => {
   const headersList = {
     'Content-Type': 'application/json',
   };
@@ -20,4 +20,11 @@ const postLike = async (id) => {
   return data;
 };
 
-export default postLike;
+export const getLikes = async () => {
+  const response = await fetch(
+    'https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/xqHl95viv3D6FREdQd3p/likes',
+  );
+  const likesData = await response.text();
+  console.log(likesData);
+  return likesData;
+};


### PR DESCRIPTION
In this branch I did the following:

When the page loads, the webapp calls the involvement API to show the item likes and combines them with the data from the base API.

make only 2 requests:

one to the base API
and one to the Involvement API.
This task does not include displaying the likes button (heart icon on the wireframe) for each item.